### PR TITLE
Updated interface definition to resolve build error

### DIFF
--- a/content/app/config.route.ts
+++ b/content/app/config.route.ts
@@ -2,10 +2,19 @@
 'use strict';
 module App
 {
-    export interface IAppRoute
-    {
+    export interface IAppRouteSettings {
+        nav: number;
+        content: string;
+    }
+
+    export interface IAppRouteConfig extends ng.route.IRoute {
+        title: string;
+        settings: IAppRouteSettings;
+    }
+
+    export interface IAppRoute {
         url: string;
-        config: ng.route.IRoute;
+        config: IAppRouteConfig;
     }
 
 


### PR DESCRIPTION
After adding the latest version to an empty project in VS2015, the build failed with a typescript compile error.  The resolution was to create the additional interfaces and modify the IAppRoute interface accordingly.
